### PR TITLE
If user is authenticated, set public=true

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,9 +18,6 @@ const routes = [
         next();
         return;
       }
-
-      // otherwise send authenticated users to public=false
-      // and unauthenticated users to public=true
       if (store.state.userIsAuthenticated) {
         let query = {...to.query, public: "true"};
         // make sure we set the include_configuration_type correctly based on the DQI setting

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -22,7 +22,7 @@ const routes = [
       // otherwise send authenticated users to public=false
       // and unauthenticated users to public=true
       if (store.state.userIsAuthenticated) {
-        let query = {...to.query, public: "false"};
+        let query = {...to.query, public: "true"};
         // make sure we set the include_configuration_type correctly based on the DQI setting
         query.exclude_calibrations = store.state.inspectorViewEnabled ? false : true;
         next({ name: 'Home', query: query});


### PR DESCRIPTION
The expectation is that users should be able to see all data they have access to, by default.

We do this in the router so that we can set it before page render.